### PR TITLE
Prevent JavaScript TypeError when not using a hint

### DIFF
--- a/app/views/layouts/lockup/_inline_js.html.erb
+++ b/app/views/layouts/lockup/_inline_js.html.erb
@@ -1,12 +1,14 @@
 setTimeout(function () {
   var hint = document.getElementById('hint');
   var hint_icon = document.getElementById('hint_icon');
-  hint_icon.onclick = function () {
-    if(hint.className.indexOf('show') < 0) {
-      hint.className = hint.className + " show";
-    }
-    else {
-      hint.className = hint.className.replace(/\sshow/, '');
+  if (hint_icon != null) {
+    hint_icon.onclick = function () {
+      if(hint.className.indexOf('show') < 0) {
+        hint.className = hint.className + " show";
+      }
+      else {
+        hint.className = hint.className.replace(/\sshow/, '');
+      }
     }
   }
 }, 50);


### PR DESCRIPTION
I am not using a hint. Just a codeword.

I was getting: Uncaught TypeError: Cannot set property 'onclick' of null
because "hint_icon.onclick" was being set when hint_icon was null.

This fixes that error.

(Thanks for the gem, BTW!)
