### PR TITLE
Add spec for handling invalid post data, and update controller per the spec

### DIFF
--- a/app/controllers/lockup/lockup_controller.rb
+++ b/app/controllers/lockup/lockup_controller.rb
@@ -15,9 +15,7 @@ module Lockup
         else
           render :nothing => true
         end
-      end
-
-      if request.post? && params[:lockup] && params[:lockup].respond_to?(:'[]')
+      elsif request.post? && params[:lockup] && params[:lockup].respond_to?(:'[]')
         @codeword = params[:lockup][:codeword].to_s.downcase
         @return_to = params[:lockup][:return_to]
         if @codeword == ENV["LOCKUP_CODEWORD"].to_s.downcase || ((Rails::VERSION::MAJOR >= 4 && Rails::VERSION::MINOR >= 1) && @codeword == Rails.application.secrets.lockup_codeword.to_s.downcase)
@@ -26,6 +24,8 @@ module Lockup
         else
           @wrong = true
         end
+      else
+        render :nothing => true
       end
     end
     

--- a/spec/controllers/lockup/lockup_controller_spec.rb
+++ b/spec/controllers/lockup/lockup_controller_spec.rb
@@ -6,4 +6,9 @@ describe Lockup::LockupController do
       post 'unlock', {use_route: :lockup, foo: 'bar'}
     end
   end
+  describe 'a malicious user requests a format that is not HTML' do
+    it 'does not fail' do
+      get 'unlock', use_route: :lockup, format: 'text'
+    end
+  end
 end


### PR DESCRIPTION
I got some 500 errors from bots posting invalid data so params[:lockup] was nil. This should fix it.
