### PR TITLE
cookie lifetime - support secrets + update version/readme

### DIFF
--- a/FIST_BUMP.md
+++ b/FIST_BUMP.md
@@ -6,6 +6,7 @@ A note of thanks from Grant ([@gblakeman](http://twitter.com/gblakeman)) and Jak
 
 <img src="http://lockupgem.com/github_host/adventure_time_fist_bump.gif" width="450" height="253" alt="Fist Bump!" />
 
+* Thanks (again) to Dan Rabinowitz (https://github.com/danrabinowitz) for adding support for customizing the length of the cookie.
 * Thanks to Nathan Broadbent (https://github.com/ndbroadbent) for some nice refactoring and an additional check.
 * Thanks (again) to Dan Rabinowitz (https://github.com/danrabinowitz) for prepping the gem for Rails 5.
 * Thanks to Dan Rabinowitz (https://github.com/danrabinowitz) for catching a js error when hints are not used & for providing some additional places for bots to die.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ The visitor is redirected and the cookie is set without them ever seeing the Loc
 
 (Lockup also makes a rudimentary attempt based on user agent to **block major search engine bots/crawlers** from following this link and indexing the site, just in case it ever gets out into the wild.)
 
+### Set a custom lifetime for cookie
+
+The cookie set by Lockup defaults to 5 years. If you want to set a shorter amount of time, you can specify a number of weeks:
+
+    ENV["COOKIE_LIFETIME_IN_WEEKS"] = 4
+
+    cookie_lifetime_in_weeks: 4
+
 ### Design Customization
 
 If you would like to change the content or design of the lockup page, you can create the directories `app/views/layouts/lockup` and `app/views/lockup/lockup` and populate them with the default content from [here](https://github.com/gblakeman/lockup/tree/master/app/views), and then customize as desired.

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -34,8 +34,18 @@ module Lockup
     end
   end
 
+  def cookie_lifetime_variable
+    if ENV["COOKIE_LIFETIME_IN_WEEKS"].present?
+      ENV["COOKIE_LIFETIME_IN_WEEKS"]
+    elsif ENV["cookie_lifetime_in_weeks"].present?
+      ENV["cookie_lifetime_in_weeks"]
+    elsif Rails.application.respond_to?(:secrets) && Rails.application.secrets.cookie_lifetime_in_weeks.present?
+      Rails.application.secrets.cookie_lifetime_in_weeks
+    end
+  end
+
   def cookie_lifetime
-    weeks = ENV['COOKIE_LIFETIME_IN_WEEKS'].to_f
+    weeks = (cookie_lifetime_variable || 0).to_f
     seconds = (weeks * 1.week).to_i
     if seconds > 0
       seconds

--- a/lib/lockup/version.rb
+++ b/lib/lockup/version.rb
@@ -1,3 +1,3 @@
 module Lockup
-  VERSION = "1.4.1"
+  VERSION = "1.4.2"
 end


### PR DESCRIPTION
A quick followup to #37. Supports Rails Secrets, bumps the version, and updates the `README`.