### PR TITLE
Don't crash if HTTP_USER_AGENT header is missing

### DIFF
--- a/app/controllers/lockup/lockup_controller.rb
+++ b/app/controllers/lockup/lockup_controller.rb
@@ -1,23 +1,26 @@
 module Lockup
   class LockupController < Lockup::ApplicationController
+    CRAWLER_REGEX = /crawl|googlebot|slurp|spider|bingbot|tracker|click|parser|spider/
+
     if self.respond_to?(:skip_before_action)
       skip_before_action :check_for_lockup
     else
       skip_before_filter :check_for_lockup
     end
-    
+
     def unlock
       if params[:lockup_codeword].present?
-        user_agent = request.env['HTTP_USER_AGENT'].downcase
-        unless user_agent.match(/crawl|googlebot|slurp|spider|bingbot|tracker|click|parser|spider/)
-          @codeword = params[:lockup_codeword].to_s.downcase
-          @return_to = params[:return_to]
-          if @codeword == lockup_codeword
-            set_cookie
-            run_redirect
-          end
-        else
+        user_agent = request.env['HTTP_USER_AGENT'].presence
+        if user_agent && user_agent.downcase.match(CRAWLER_REGEX)
           head :ok
+          return
+        end
+
+        @codeword = params[:lockup_codeword].to_s.downcase
+        @return_to = params[:return_to]
+        if @codeword == lockup_codeword
+          set_cookie
+          run_redirect
         end
       elsif request.post?
         if params[:lockup].present? && params[:lockup].respond_to?(:'[]')
@@ -36,13 +39,13 @@ module Lockup
         respond_to :html
       end
     end
-    
+
     private
-    
+
     def set_cookie
       cookies[:lockup] = { value: @codeword.to_s.downcase, expires: (Time.now + cookie_lifetime) }
     end
-    
+
     def run_redirect
       if @return_to.present?
         redirect_to "#{@return_to}"


### PR DESCRIPTION
I was using `HTTParty` to send some requests and forget to set the user agent header, which caused an error. This PR prevents the server from crashing if the `HTTP_USER_AGENT` header is missing.