### PR TITLE
Full credentials support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you think you might need a hint:
 
     ENV["LOCKUP_HINT"] = 'Something that you do not tell everyone.'
 
-If you’re using Rails 4.1 or greater, you can add your Lockup Codeword via Rails Secrets functionality in your secrets.yml file:
+If you’re using Rails >= 4.1 or Rails >= 5.2, you can add your Lockup Codeword via Rails Secrets or Rails Credentials functionality in your secrets.yml or credentials.yml.enc file, respectively:
 
     lockup_codeword: 'love'
 

--- a/app/helpers/lockup/lockup_helper.rb
+++ b/app/helpers/lockup/lockup_helper.rb
@@ -13,8 +13,10 @@ module Lockup
         ENV["LOCKUP_HINT"].to_s
       elsif ENV["lockup_hint"].present?
         ENV["lockup_hint"].to_s
-      elsif (Rails::VERSION::MAJOR >= 4 && Rails::VERSION::MINOR >= 1) && Rails.application.secrets.lockup_hint.present?
+      elsif Rails.application.respond_to?(:secrets) && Rails.application.secrets.lockup_hint.present?
         Rails.application.secrets.lockup_hint.to_s
+      elsif Rails.application.respond_to?(:credentials) && Rails.application.credentials.lockup_hint.present?
+        Rails.application.credentials.lockup_hint.to_s
       end
     end
 

--- a/app/helpers/lockup/lockup_helper.rb
+++ b/app/helpers/lockup/lockup_helper.rb
@@ -2,11 +2,10 @@ module Lockup
   module LockupHelper
 
     def lockup_hint_present?
-      if ENV["LOCKUP_HINT"].present? || ENV["lockup_hint"].present? || ((Rails::VERSION::MAJOR >= 4 && Rails::VERSION::MINOR >= 1) && Rails.application.secrets.lockup_hint.present?)
-        true
-      else
-        false
-      end
+      ENV["LOCKUP_HINT"].present? ||
+      ENV["lockup_hint"].present? ||
+      (Rails.application.respond_to?(:secrets) && Rails.application.secrets.lockup_hint.present?) ||
+      (Rails.application.respond_to?(:credentials) && Rails.application.credentials.lockup_hint.present?)
     end
 
     def lockup_hint_display

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -49,6 +49,8 @@ module Lockup
       ENV["cookie_lifetime_in_weeks"]
     elsif Rails.application.respond_to?(:secrets) && Rails.application.secrets.cookie_lifetime_in_weeks.present?
       Rails.application.secrets.cookie_lifetime_in_weeks
+    elsif Rails.application.respond_to?(:credentials) && Rails.application.credentials.cookie_lifetime_in_weeks.present?
+      Rails.application.credentials.cookie_lifetime_in_weeks
     end
   end
 


### PR DESCRIPTION
Only `lockup_codeword` could be used via credentials. Now `lockup_hint` and `cookie_lifetime_in_weeks` can be used.