### PR TITLE
Namespacing... and more!

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you think you might need a hint:
 
     ENV["LOCKUP_HINT"] = 'Something that you do not tell everyone.'
 
-If you’re using Rails 4.1 or greater, you can add your Lockup Codeword via Rails Secrets functionality in your secrets.yml file:
+If you’re using Rails >= 4.1 or Rails >= 5.2, you can add your Lockup Codeword via Rails Secrets or Rails Credentials functionality in your secrets.yml or credentials.yml.enc file, respectively:
 
     lockup_codeword: 'love'
 

--- a/app/controllers/lockup/lockup_controller.rb
+++ b/app/controllers/lockup/lockup_controller.rb
@@ -43,7 +43,7 @@ module Lockup
     private
 
     def set_cookie
-      cookies[:lockup] = { value: @codeword.to_s.downcase, expires: (Time.now + cookie_lifetime) }
+      cookies[:lockup] = { value: @codeword.to_s.downcase, expires: (Time.now + lockup_cookie_lifetime) }
     end
 
     def run_redirect

--- a/app/controllers/lockup/lockup_controller.rb
+++ b/app/controllers/lockup/lockup_controller.rb
@@ -18,7 +18,7 @@ module Lockup
 
         @codeword = params[:lockup_codeword].to_s.downcase
         @return_to = params[:return_to]
-        if @codeword == lockup_codeword
+        if @codeword == lockup_codeword.to_s.downcase
           set_cookie
           run_redirect
         end
@@ -26,7 +26,7 @@ module Lockup
         if params[:lockup].present? && params[:lockup].respond_to?(:'[]')
           @codeword = params[:lockup][:codeword].to_s.downcase
           @return_to = params[:lockup][:return_to]
-          if @codeword == lockup_codeword
+          if @codeword == lockup_codeword.to_s.downcase
             set_cookie
             run_redirect
           else

--- a/app/helpers/lockup/lockup_helper.rb
+++ b/app/helpers/lockup/lockup_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Lockup
   module LockupHelper
     def lockup_hint

--- a/app/helpers/lockup/lockup_helper.rb
+++ b/app/helpers/lockup/lockup_helper.rb
@@ -13,8 +13,10 @@ module Lockup
         ENV["LOCKUP_HINT"].to_s
       elsif ENV["lockup_hint"].present?
         ENV["lockup_hint"].to_s
-      elsif (Rails::VERSION::MAJOR >= 4 && Rails::VERSION::MINOR >= 1) && Rails.application.secrets.lockup_hint.present?
+      elsif Rails.application.respond_to?(:secrets) && Rails.application.secrets.lockup_hint.present?
         Rails.application.secrets.lockup_hint.to_s
+      elsif Rails.application.respond_to?(:credentials) && Rails.application.credentials.lockup_hint.present?
+        Rails.application.credentials.lockup_hint.to_s
       end
     end
 

--- a/app/helpers/lockup/lockup_helper.rb
+++ b/app/helpers/lockup/lockup_helper.rb
@@ -7,7 +7,7 @@ module Lockup
         ENV['LOCKUP_HINT'] ||
         ENV['lockup_hint'] ||
         lockup_hint_from_config(:secrets) ||
-        lockup_hint_from_config(:credentials)
+        lockup_hint_from_config
     end
 
     private

--- a/app/helpers/lockup/lockup_helper.rb
+++ b/app/helpers/lockup/lockup_helper.rb
@@ -6,20 +6,8 @@ module Lockup
       @lockup_hint ||=
         ENV['LOCKUP_HINT'] ||
         ENV['lockup_hint'] ||
-        lockup_hint_from_config(:secrets) ||
-        lockup_hint_from_config
-    end
-
-    private
-
-    def lockup_hint_from_config(secrets_or_credentials = :credentials)
-      return unless Rails.application.respond_to?(secrets_or_credentials)
-
-      store = Rails.application.public_send(secrets_or_credentials)
-
-      store.lockup.respond_to?(:fetch) &&
-        store.lockup.fetch(:hint, store.lockup_hint) ||
-        store.lockup_hint
+        ::Lockup.from_config(:hint, :secrets) ||
+        ::Lockup.from_config(:hint)
     end
   end
 end

--- a/app/helpers/lockup/lockup_helper.rb
+++ b/app/helpers/lockup/lockup_helper.rb
@@ -1,23 +1,10 @@
 module Lockup
   module LockupHelper
-
-    def lockup_hint_present?
-      ENV["LOCKUP_HINT"].present? ||
-      ENV["lockup_hint"].present? ||
-      (Rails.application.respond_to?(:secrets) && Rails.application.secrets.lockup_hint.present?) ||
-      (Rails.application.respond_to?(:credentials) && Rails.application.credentials.lockup_hint.present?)
-    end
-
-    def lockup_hint_display
-      if ENV["LOCKUP_HINT"].present?
-        ENV["LOCKUP_HINT"].to_s
-      elsif ENV["lockup_hint"].present?
-        ENV["lockup_hint"].to_s
-      elsif Rails.application.respond_to?(:secrets) && Rails.application.secrets.lockup_hint.present?
-        Rails.application.secrets.lockup_hint.to_s
-      elsif Rails.application.respond_to?(:credentials) && Rails.application.credentials.lockup_hint.present?
-        Rails.application.credentials.lockup_hint.to_s
-      end
+    def lockup_hint
+      ENV['LOCKUP_HINT'] ||
+        ENV['lockup_hint'] ||
+        lockup_hint_from_config(:secrets) ||
+        lockup_hint_from_config(:credentials)
     end
 
     private

--- a/app/helpers/lockup/lockup_helper.rb
+++ b/app/helpers/lockup/lockup_helper.rb
@@ -2,11 +2,10 @@ module Lockup
   module LockupHelper
 
     def lockup_hint_present?
-      if ENV["LOCKUP_HINT"].present? || ENV["lockup_hint"].present? || ((Rails::VERSION::MAJOR >= 4 && Rails::VERSION::MINOR >= 1) && Rails.application.secrets.lockup_hint.present?)
-        true
-      else
-        false
-      end
+      ENV["LOCKUP_HINT"].present? ||
+      ENV["lockup_hint"].present? ||
+      (Rails.application.respond_to?(:secrets) && Rails.application.secrets.lockup_hint.present?) ||
+      (Rails.application.respond_to?(:credentials) && Rails.application.credentials.lockup_hint.present?)
     end
 
     def lockup_hint_display

--- a/app/helpers/lockup/lockup_helper.rb
+++ b/app/helpers/lockup/lockup_helper.rb
@@ -1,7 +1,8 @@
 module Lockup
   module LockupHelper
     def lockup_hint
-      ENV['LOCKUP_HINT'] ||
+      @lockup_hint ||=
+        ENV['LOCKUP_HINT'] ||
         ENV['lockup_hint'] ||
         lockup_hint_from_config(:secrets) ||
         lockup_hint_from_config(:credentials)

--- a/app/helpers/lockup/lockup_helper.rb
+++ b/app/helpers/lockup/lockup_helper.rb
@@ -20,5 +20,16 @@ module Lockup
       end
     end
 
+    private
+
+    def lockup_hint_from_config(secrets_or_credentials = :credentials)
+      return unless Rails.application.respond_to?(secrets_or_credentials)
+
+      store = Rails.application.public_send(secrets_or_credentials)
+
+      store.lockup.respond_to?(:fetch) &&
+        store.lockup.fetch(:hint, store.lockup_hint) ||
+        store.lockup_hint
+    end
   end
 end

--- a/app/views/lockup/lockup/unlock.html.erb
+++ b/app/views/lockup/lockup/unlock.html.erb
@@ -13,9 +13,9 @@
     <p><%= form.password_field "codeword", value: @codeword, class: 'nope', autofocus: true %></p>
   <% end %>
     
-  <% if lockup_hint_present? %>
+  <% if lockup_hint %>
     <p id='hint_icon'>?</p>
-    <p id='hint'><%= lockup_hint_display %></p>
+    <p id='hint'><%= lockup_hint %></p>
   <% end %>
 
   <% if params[:return_to].present? %>

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -50,8 +50,7 @@ module Lockup
   end
 
   def lockup_cookie_lifetime
-    weeks = (cookie_lifetime || 0).to_f
-    seconds = (weeks * 1.week).to_i
+    seconds = (cookie_lifetime.to_f * 1.week).to_i
     if seconds > 0
       seconds
     else

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -6,7 +6,7 @@ module Lockup
   extend ActiveSupport::Concern
 
   included do
-    if self.respond_to?(:before_action)
+    if respond_to?(:before_action)
       before_action :check_for_lockup, except: ['unlock']
     else
       before_filter :check_for_lockup, except: ['unlock']

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -42,7 +42,8 @@ module Lockup
   end
 
   def cookie_lifetime_variable
-    ENV["COOKIE_LIFETIME_IN_WEEKS"] ||
+    @cookie_lifetime_variable ||=
+      ENV["COOKIE_LIFETIME_IN_WEEKS"] ||
       ENV["cookie_lifetime_in_weeks"] ||
       Lockup.from_config(:cookie_lifetime_in_weeks, :secrets) ||
       Lockup.from_config(:cookie_lifetime_in_weeks)

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -35,9 +35,9 @@ module Lockup
 
   def lockup_codeword_present?
     ENV["LOCKUP_CODEWORD"].present? ||
-    ENV["lockup_codeword"].present? ||
-    (Rails.application.respond_to?(:secrets) && Rails.application.secrets.lockup_codeword.present?) ||
-    (Rails.application.respond_to?(:credentials) && Rails.application.credentials.lockup_codeword.present?)
+      ENV["lockup_codeword"].present? ||
+      Lockup.from_config(:codeword, :secrets).present? ||
+      Lockup.from_config(:codeword).present?
   end
 
   def lockup_codeword
@@ -45,10 +45,10 @@ module Lockup
       ENV["LOCKUP_CODEWORD"].to_s.downcase
     elsif ENV["lockup_codeword"].present?
       ENV["lockup_codeword"].to_s.downcase
-    elsif Rails.application.respond_to?(:secrets) && Rails.application.secrets.lockup_codeword.present?
-      Rails.application.secrets.lockup_codeword.to_s.downcase
-    elsif Rails.application.respond_to?(:credentials) && Rails.application.credentials.lockup_codeword.present?
-      Rails.application.credentials.lockup_codeword.to_s.downcase
+    elsif Lockup.from_config(:codeword, :secrets).present?
+      Lockup.from_config(:codeword, :secrets).downcase
+    elsif Lockup.from_config(:codeword).present?
+      Lockup.from_config(:codeword).downcase
     end
   end
 

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -35,20 +35,20 @@ module Lockup
     )
   end
 
-  def lockup_codeword
-    @lockup_codeword ||=
-      ENV['LOCKUP_CODEWORD'] ||
-      ENV['lockup_codeword'] ||
-      Lockup.from_config(:codeword, :secrets) ||
-      Lockup.from_config(:codeword)
-  end
-
   def cookie_lifetime
     @cookie_lifetime ||=
       ENV['COOKIE_LIFETIME_IN_WEEKS'] ||
       ENV['cookie_lifetime_in_weeks'] ||
       Lockup.from_config(:cookie_lifetime_in_weeks, :secrets) ||
       Lockup.from_config(:cookie_lifetime_in_weeks)
+  end
+
+  def lockup_codeword
+    @lockup_codeword ||=
+      ENV['LOCKUP_CODEWORD'] ||
+      ENV['lockup_codeword'] ||
+      Lockup.from_config(:codeword, :secrets) ||
+      Lockup.from_config(:codeword)
   end
 
   def lockup_cookie_lifetime

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -49,6 +49,8 @@ module Lockup
       ENV["cookie_lifetime_in_weeks"]
     elsif Rails.application.respond_to?(:secrets) && Rails.application.secrets.cookie_lifetime_in_weeks.present?
       Rails.application.secrets.cookie_lifetime_in_weeks
+    elsif Rails.application.respond_to?(:credentials) && Rails.application.credentials.cookie_lifetime_in_weeks.present?
+      Rails.application.credentials.cookie_lifetime_in_weeks
     end
   end
 

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -11,6 +11,16 @@ module Lockup
     end
   end
 
+  def self.from_config(setting, secrets_or_credentials = :credentials)
+    return unless Rails.application.respond_to?(secrets_or_credentials)
+
+    store = Rails.application.public_send(secrets_or_credentials)
+
+    store.lockup.respond_to?(:fetch) &&
+      store.lockup.fetch(setting, store.public_send("lockup_#{setting}")) ||
+      store.public_send("lockup_#{setting}")
+  end
+
   private
 
   def check_for_lockup

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -18,7 +18,7 @@ module Lockup
 
     store.lockup.respond_to?(:fetch) &&
       store.lockup.fetch(setting, store.public_send("lockup_#{setting}")) ||
-      store.public_send("lockup_#{setting}")
+      store.public_send("lockup_#{setting}") || store.public_send(setting)
   end
 
   private

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -1,13 +1,13 @@
-require "lockup/engine"
+require 'lockup/engine'
 
 module Lockup
   extend ActiveSupport::Concern
 
   included do
     if self.respond_to?(:before_action)
-      before_action :check_for_lockup, except: ["unlock"]
+      before_action :check_for_lockup, except: ['unlock']
     else
-      before_filter :check_for_lockup, except: ["unlock"]
+      before_filter :check_for_lockup, except: ['unlock']
     end
   end
 
@@ -35,16 +35,16 @@ module Lockup
 
   def lockup_codeword
     @lockup_codeword ||=
-      ENV["LOCKUP_CODEWORD"] ||
-      ENV["lockup_codeword"] ||
+      ENV['LOCKUP_CODEWORD'] ||
+      ENV['lockup_codeword'] ||
       Lockup.from_config(:codeword, :secrets) ||
       Lockup.from_config(:codeword)
   end
 
   def cookie_lifetime
     @cookie_lifetime ||=
-      ENV["COOKIE_LIFETIME_IN_WEEKS"] ||
-      ENV["cookie_lifetime_in_weeks"] ||
+      ENV['COOKIE_LIFETIME_IN_WEEKS'] ||
+      ENV['cookie_lifetime_in_weeks'] ||
       Lockup.from_config(:cookie_lifetime_in_weeks, :secrets) ||
       Lockup.from_config(:cookie_lifetime_in_weeks)
   end

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -24,8 +24,8 @@ module Lockup
   private
 
   def check_for_lockup
-    return unless respond_to?(:lockup) && lockup_codeword_present?
-    return if cookies[:lockup].present? && cookies[:lockup] == lockup_codeword
+    return unless respond_to?(:lockup) && lockup_codeword
+    return if cookies[:lockup].present? && cookies[:lockup] == lockup_codeword.to_s.downcase
 
     redirect_to lockup.unlock_path(
       return_to: request.fullpath.split('?lockup_codeword')[0],
@@ -33,23 +33,11 @@ module Lockup
     )
   end
 
-  def lockup_codeword_present?
-    ENV["LOCKUP_CODEWORD"].present? ||
-      ENV["lockup_codeword"].present? ||
-      Lockup.from_config(:codeword, :secrets).present? ||
-      Lockup.from_config(:codeword).present?
-  end
-
   def lockup_codeword
-    if ENV["LOCKUP_CODEWORD"].present?
-      ENV["LOCKUP_CODEWORD"].to_s.downcase
-    elsif ENV["lockup_codeword"].present?
-      ENV["lockup_codeword"].to_s.downcase
-    elsif Lockup.from_config(:codeword, :secrets).present?
-      Lockup.from_config(:codeword, :secrets).downcase
-    elsif Lockup.from_config(:codeword).present?
-      Lockup.from_config(:codeword).downcase
-    end
+    ENV["LOCKUP_CODEWORD"] ||
+      ENV["lockup_codeword"] ||
+      Lockup.from_config(:codeword, :secrets) ||
+      Lockup.from_config(:codeword)
   end
 
   def cookie_lifetime_variable

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -41,16 +41,16 @@ module Lockup
       Lockup.from_config(:codeword)
   end
 
-  def cookie_lifetime_variable
-    @cookie_lifetime_variable ||=
+  def cookie_lifetime
+    @cookie_lifetime ||=
       ENV["COOKIE_LIFETIME_IN_WEEKS"] ||
       ENV["cookie_lifetime_in_weeks"] ||
       Lockup.from_config(:cookie_lifetime_in_weeks, :secrets) ||
       Lockup.from_config(:cookie_lifetime_in_weeks)
   end
 
-  def cookie_lifetime
-    weeks = (cookie_lifetime_variable || 0).to_f
+  def lockup_cookie_lifetime
+    weeks = (cookie_lifetime || 0).to_f
     seconds = (weeks * 1.week).to_i
     if seconds > 0
       seconds

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -34,7 +34,8 @@ module Lockup
   end
 
   def lockup_codeword
-    ENV["LOCKUP_CODEWORD"] ||
+    @lockup_codeword ||=
+      ENV["LOCKUP_CODEWORD"] ||
       ENV["lockup_codeword"] ||
       Lockup.from_config(:codeword, :secrets) ||
       Lockup.from_config(:codeword)

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -31,7 +31,7 @@ module Lockup
 
     redirect_to lockup.unlock_path(
       return_to: request.fullpath.split('?lockup_codeword')[0],
-      lockup_codeword: params[:lockup_codeword],
+      lockup_codeword: params[:lockup_codeword]
     )
   end
 

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -42,15 +42,10 @@ module Lockup
   end
 
   def cookie_lifetime_variable
-    if ENV["COOKIE_LIFETIME_IN_WEEKS"].present?
-      ENV["COOKIE_LIFETIME_IN_WEEKS"]
-    elsif ENV["cookie_lifetime_in_weeks"].present?
-      ENV["cookie_lifetime_in_weeks"]
-    elsif Rails.application.respond_to?(:secrets) && Rails.application.secrets.cookie_lifetime_in_weeks.present?
-      Rails.application.secrets.cookie_lifetime_in_weeks
-    elsif Rails.application.respond_to?(:credentials) && Rails.application.credentials.cookie_lifetime_in_weeks.present?
-      Rails.application.credentials.cookie_lifetime_in_weeks
-    end
+    ENV["COOKIE_LIFETIME_IN_WEEKS"] ||
+      ENV["cookie_lifetime_in_weeks"] ||
+      Lockup.from_config(:cookie_lifetime_in_weeks, :secrets) ||
+      Lockup.from_config(:cookie_lifetime_in_weeks)
   end
 
   def cookie_lifetime

--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'lockup/engine'
 
 module Lockup

--- a/spec/controllers/lockup/lockup_controller_spec.rb
+++ b/spec/controllers/lockup/lockup_controller_spec.rb
@@ -21,7 +21,7 @@ describe Lockup::LockupController do
       before { ENV['COOKIE_LIFETIME_IN_WEEKS'] = '52' }
 
       it "returns the integer" do
-        controller.send(:cookie_lifetime).should eq(52.weeks)
+        controller.send(:lockup_cookie_lifetime).should eq(52.weeks)
       end
     end
 
@@ -29,7 +29,7 @@ describe Lockup::LockupController do
       before { ENV['COOKIE_LIFETIME_IN_WEEKS'] = 'invalid value' }
 
       it "returns the integer" do
-        controller.send(:cookie_lifetime).should eq(5.years)
+        controller.send(:lockup_cookie_lifetime).should eq(5.years)
       end
     end
 
@@ -37,7 +37,7 @@ describe Lockup::LockupController do
       before { ENV.delete('COOKIE_LIFETIME_IN_WEEKS') }
 
       it "returns the integer" do
-        controller.send(:cookie_lifetime).should eq(5.years)
+        controller.send(:lockup_cookie_lifetime).should eq(5.years)
       end
     end
   end

--- a/spec/features/access_restricted_spec.rb
+++ b/spec/features/access_restricted_spec.rb
@@ -24,7 +24,7 @@ describe "Accessing a page in the application" do
   end
 
   context "with a configured code word" do
-    before { ENV['LOCKUP_CODEWORD'] = 'omgponies' }
+    before { ENV['LOCKUP_CODEWORD'] = 'OMGponies' }
 
     it "redirects to the password entry screen" do
       visit '/posts'


### PR DESCRIPTION
I kinda went down the rabbit hole...

This was branched from the PR #50 branch.  Hopefully it all looks good to you. If not, I can find my way back out of the rabbit hole.

I didn't update `README.md`

This allows for namespaced properties falling back up the tree. One should be able to mix and match locations of the properties, e.g. `lockup_hint` and `lockup.codeword`. It should also support unprefixed properties such as the `cookie_lifetime_in_weeks`.  This also means that if someone is using `codeword` or `hint` in their YAML files, it will use those.