### PR TITLE
Relax gemspec for Rails 6 (Fix #57)

### DIFF
--- a/lockup.gemspec
+++ b/lockup.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 3", "< 6"
+  s.add_dependency "rails", ">= 3", "< 6.1"
 
   s.add_development_dependency 'rspec-rails', "~> 3.5"
   s.add_development_dependency 'capybara', "~> 2.9"


### PR DESCRIPTION
Hi there!

This PR updates the gemspec to allow it to work since Rails 6.0.0 was released this morning.

I ran the specs locally and they appear to be passing :) 

I went ahead and bumped it for 6.1 but what do you think about removing the cap on the Rails dependency to prevent the need to edit later? 

This fixes #57 

Edit: Whoops, just saw the big re-write, feel free to close that if you guys intend to ship that instead of this :) 