### PR TITLE
Support Rails 6.1 and Rails 6.2

### DIFF
--- a/FIST_BUMP.md
+++ b/FIST_BUMP.md
@@ -6,7 +6,7 @@ A note of thanks from Grant ([@gblakeman](http://twitter.com/gblakeman)) and Jak
 
 <img src="http://lockupgem.com/github_host/adventure_time_fist_bump.gif" width="450" height="253" alt="Fist Bump!" />
 
-* Thanks to @king601 (https://github.com/king601) for tweaks to support Rails 6.
+* Thanks to @afomera (https://github.com/afomera) for tweaks to support Rails 6 & Rails 6.1.
 * Thanks to @dankimio (https://github.com/dankimio) for README tweaks.
 * Thanks to @guaguasi (https://github.com/guaguasi) for the addition Credentials support and some great refactoring.
 * Thanks to Maxim Filippov (https://github.com/maksimf) for the autofocus input.

--- a/lockup.gemspec
+++ b/lockup.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 3", "< 6.1"
+  s.add_dependency "rails", ">= 3", "< 7.0"
 
   s.add_development_dependency 'rspec-rails', "~> 3.5"
   s.add_development_dependency 'capybara', "~> 2.9"


### PR DESCRIPTION
Hi @gblakeman, thanks for the gem! We've been using the gem in production (well not directly in production, our staging envs) using the Rails 6.1 release candidates just fine. I've relaxed the Gemspec to support 6.1 and the eventual 6.2 Rails versions.

I also changed my GitHub username in between the last version, so I modified FIST_BUMP to reflect my new username. See #58 for proof/confirmation.