### PR TITLE
Add more defensive cookie check

### DIFF
--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -27,7 +27,7 @@ module Lockup
 
   def check_for_lockup
     return unless respond_to?(:lockup) && lockup_codeword
-    return if cookies[:lockup].present? && cookies[:lockup] == lockup_codeword.to_s.downcase
+    return if cookies && cookies[:lockup].present? && cookies[:lockup] == lockup_codeword.to_s.downcase
 
     redirect_to lockup.unlock_path(
       return_to: request.fullpath.split('?lockup_codeword')[0],


### PR DESCRIPTION
First, thanks for a great library!

While adding a cookie consent library we noticed lockup started failing due to the cookies hash being nil (sentry.io screenshot below). This PR adds a bit more defensive logic to account for the case

![image](https://user-images.githubusercontent.com/470852/101495826-02545d80-3937-11eb-87b9-c151c5d51e70.png)