### PR TITLE
Rails Health Controller monkey patch

### DIFF
--- a/lib/lockup.rb
+++ b/lib/lockup.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lockup/engine'
+require 'rails/health_controller_decorator'
 
 module Lockup
   extend ActiveSupport::Concern

--- a/lib/rails/health_controller_decorator.rb
+++ b/lib/rails/health_controller_decorator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Rails
+  module HealthControllerDecorator
+    def check_for_lockup
+      true
+    end
+
+    klass = '::Rails::HealthController'.safe_constantize
+    klass.prepend(self) if klass
+  end
+end


### PR DESCRIPTION
I'd like to suggest this change to address this issue: https://github.com/interdiscipline/lockup/issues/77

Override the lockup check method to do nothing in the Rails health controller.

According to my test, using `skip_before_action` trigger [the `rescue_from(Exception)` defined here](https://github.com/rails/rails/blob/db4215a2574210f9b9841e65a4cc11b84bbff2f4/railties/lib/rails/health_controller.rb#L36), even with the `raise: false` option. For this reason, overriding the check seem appropriate instead.

This simple monkey-patch should gracefully do nothing on older version of Rails where the `Rails::HealthController` doesn't exist.