### PR TITLE
Fix partials delimitations comments breaking inline CSS/JS

### DIFF
--- a/app/views/layouts/lockup/_inline_css.html.erb
+++ b/app/views/layouts/lockup/_inline_css.html.erb
@@ -1,3 +1,4 @@
+<style>
 body {
   padding: 12%;
   font-family: Helvetica, sans-serif;
@@ -293,3 +294,4 @@ form p {
     margin-bottom: 28px;
   }
 }
+</style>

--- a/app/views/layouts/lockup/_inline_js.html.erb
+++ b/app/views/layouts/lockup/_inline_js.html.erb
@@ -1,3 +1,4 @@
+<script>
 setTimeout(function () {
   var hint = document.getElementById('hint');
   var hint_icon = document.getElementById('hint_icon');
@@ -12,3 +13,4 @@ setTimeout(function () {
     }
   }
 }, 50);
+</script>

--- a/app/views/layouts/lockup/application.html.erb
+++ b/app/views/layouts/lockup/application.html.erb
@@ -6,12 +6,9 @@
     <meta name="viewport" content="width=device-width,initial-scale = 1.0,maximum-scale = 1.0,user-scalable=no" />
 
     <title>Please enter the code word to continue&hellip;</title>
-    <style>
-      <%= render partial: 'layouts/lockup/inline_css' %>
-    </style>
-    <script>
-      <%= render partial: 'layouts/lockup/inline_js' %>
-    </script>
+
+    <%= render partial: 'layouts/lockup/inline_css' %>
+    <%= render partial: 'layouts/lockup/inline_js' %>
   </head>
 
   <body>


### PR DESCRIPTION
Relevant issue: https://github.com/interdiscipline/lockup/issues/78

In a development environment, Rails inject HTML comments denoting the start and end of partials. This behavior break the content of the inline CSS/JS since the comments are using the wrong syntax.